### PR TITLE
Handle multiple JUnit test suites per file

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -26,7 +26,7 @@ junit_report_files.each do |file|
   xml = File.read(file)
   doc = REXML::Document.new(xml)
 
-  doc.elements.each('*/testcase') do |testcase|
+  REXML::XPath.each(doc, '//testsuite//testcase') do |testcase|
     name = testcase.attributes['name'].to_s
     classname = testcase.attributes['classname'].to_s
     testcase.elements.each("failure") do |failure|

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -7,6 +7,7 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit-1.xml
+      Parsing junit-3.xml
       Parsing junit-2.xml
       --- ❓ Checking failures
       There were no failures/errors 🙌
@@ -20,11 +21,12 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit-1.xml
+      Parsing junit-3.xml
       Parsing junit-2.xml
       --- ❓ Checking failures
-      There are 2 failures/errors 😭
+      There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
-      2 failures:
+      4 failures:
       
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -57,6 +59,40 @@ describe "Junit annotate plugin parser" do
       ./spec/support/log.rb:17:in `run'
       ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
       
+      in <a href="#3">Job #3</a>
+      </details>
+
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+      
+      <code><pre>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+      
+        expected: 250
+             got: 500
+      
+        (compared using eql?)
+      ./spec/models/account_spec.rb:78:in `block (3 levels) in <top (required)>'
+      ./spec/support/database.rb:16:in `block (2 levels) in <top (required)>'
+      ./spec/support/log.rb:17:in `run'
+      ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
+      
+      in <a href="#3">Job #3</a>
+      </details>
+      
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
+      
+      <code><pre>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+      
+        expected: 700
+             got: 500
+      
+        (compared using eql?)
+      ./spec/models/account_spec.rb:78:in `block (3 levels) in <top (required)>'
+      ./spec/support/database.rb:16:in `block (2 levels) in <top (required)>'
+      ./spec/support/log.rb:17:in `run'
+      ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
+      
       in <a href="#2">Job #2</a>
       </details>
     OUTPUT
@@ -69,11 +105,12 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit-1.xml
+      Parsing junit-3.xml
       Parsing junit-2.xml
       --- ❓ Checking failures
-      There are 2 failures/errors 😭
+      There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
-      1 failure and 1 error:
+      2 failures and 2 errors:
       
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -90,6 +127,40 @@ describe "Junit annotate plugin parser" do
       ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
       
       in <a href="#1">Job #1</a>
+      </details>
+      
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
+      
+      <code><pre>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+      
+        expected: 700
+             got: 500
+      
+        (compared using eql?)
+      ./spec/models/account_spec.rb:78:in `block (3 levels) in <top (required)>'
+      ./spec/support/database.rb:16:in `block (2 levels) in <top (required)>'
+      ./spec/support/log.rb:17:in `run'
+      ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
+      
+      in <a href="#3">Job #3</a>
+      </details>
+
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+      
+      <code><pre>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+      
+        expected: 250
+             got: 500
+      
+        (compared using eql?)
+      ./spec/models/account_spec.rb:78:in `block (3 levels) in <top (required)>'
+      ./spec/support/database.rb:16:in `block (2 levels) in <top (required)>'
+      ./spec/support/log.rb:17:in `run'
+      ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
+      
+      in <a href="#3">Job #3</a>
       </details>
       
       <details>
@@ -149,11 +220,12 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing sub-dir/junit-1.xml
+      Parsing sub-dir/junit-3.xml
       Parsing sub-dir/junit-2.xml
       --- ❓ Checking failures
-      There are 2 failures/errors 😭
+      There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
-      2 failures:
+      4 failures:
       
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -170,6 +242,40 @@ describe "Junit annotate plugin parser" do
       ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
       
       in <a href="#1">Job #1</a>
+      </details>
+      
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
+      
+      <code><pre>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+      
+        expected: 700
+             got: 500
+      
+        (compared using eql?)
+      ./spec/models/account_spec.rb:78:in `block (3 levels) in <top (required)>'
+      ./spec/support/database.rb:16:in `block (2 levels) in <top (required)>'
+      ./spec/support/log.rb:17:in `run'
+      ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
+      
+      in <a href="#3">Job #3</a>
+      </details>
+
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+      
+      <code><pre>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+      
+        expected: 250
+             got: 500
+      
+        (compared using eql?)
+      ./spec/models/account_spec.rb:78:in `block (3 levels) in <top (required)>'
+      ./spec/support/database.rb:16:in `block (2 levels) in <top (required)>'
+      ./spec/support/log.rb:17:in `run'
+      ./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'</pre></code>
+      
+      in <a href="#3">Job #3</a>
       </details>
       
       <details>

--- a/ruby/tests/no-test-failures/junit-3.xml
+++ b/ruby/tests/no-test-failures/junit-3.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.020013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00" file="./spec/models/account_spec.rb" time="0.020013"/>
+  </testsuite>
+  <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127"/>
+  </testsuite>
+</testsuites>

--- a/ruby/tests/test-failure-and-error/junit-3.xml
+++ b/ruby/tests/test-failure-and-error/junit-3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.967127">
+      <failure message=" expected: 700 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+
+  expected: 700
+       got: 500
+
+  (compared using eql?)
+./spec/models/account_spec.rb:78:in `block (3 levels) in &lt;top (required)&gt;&apos;
+./spec/support/database.rb:16:in `block (2 levels) in &lt;top (required)&gt;&apos;
+./spec/support/log.rb:17:in `run&apos;
+./spec/support/log.rb:66:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="1" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127">
+      <error message=" expected: 250 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+
+  expected: 250
+       got: 500
+
+  (compared using eql?)
+./spec/models/account_spec.rb:78:in `block (3 levels) in &lt;top (required)&gt;&apos;
+./spec/support/database.rb:16:in `block (2 levels) in &lt;top (required)&gt;&apos;
+./spec/support/log.rb:17:in `run&apos;
+./spec/support/log.rb:66:in `block (2 levels) in &lt;top (required)&gt;&apos;</error>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/ruby/tests/tests-in-sub-dirs/sub-dir/junit-3.xml
+++ b/ruby/tests/tests-in-sub-dirs/sub-dir/junit-3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.967127">
+      <failure message=" expected: 700 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+
+  expected: 700
+       got: 500
+
+  (compared using eql?)
+./spec/models/account_spec.rb:78:in `block (3 levels) in &lt;top (required)&gt;&apos;
+./spec/support/database.rb:16:in `block (2 levels) in &lt;top (required)&gt;&apos;
+./spec/support/log.rb:17:in `run&apos;
+./spec/support/log.rb:66:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="rspec" tests="2" skipped="0" failures="1" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127">
+      <failure message=" expected: 250 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+
+  expected: 250
+       got: 500
+
+  (compared using eql?)
+./spec/models/account_spec.rb:78:in `block (3 levels) in &lt;top (required)&gt;&apos;
+./spec/support/database.rb:16:in `block (2 levels) in &lt;top (required)&gt;&apos;
+./spec/support/log.rb:17:in `run&apos;
+./spec/support/log.rb:66:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/ruby/tests/two-test-failures/junit-3.xml
+++ b/ruby/tests/two-test-failures/junit-3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.967127">
+      <failure message=" expected: 700 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+
+  expected: 700
+       got: 500
+
+  (compared using eql?)
+./spec/models/account_spec.rb:78:in `block (3 levels) in &lt;top (required)&gt;&apos;
+./spec/support/database.rb:16:in `block (2 levels) in &lt;top (required)&gt;&apos;
+./spec/support/log.rb:17:in `run&apos;
+./spec/support/log.rb:66:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="rspec" tests="2" skipped="0" failures="1" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127">
+      <failure message=" expected: 250 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
+
+  expected: 250
+       got: 500
+
+  (compared using eql?)
+./spec/models/account_spec.rb:78:in `block (3 levels) in &lt;top (required)&gt;&apos;
+./spec/support/database.rb:16:in `block (2 levels) in &lt;top (required)&gt;&apos;
+./spec/support/log.rb:17:in `run&apos;
+./spec/support/log.rb:66:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This PR makes the parser a little more flexible in that it will handle multiple test suites found in the same JUnit doc (it's common for test tooling to output JUnit/XUnit results in this concatenated format).

It now handles:
```xml
<testsuites>
  <testsuite>
    <testcase/>
    <testcase/>
  </testsuite>
  <testsuite>
   ...
  </testsuite>
</testsuites>
```
Original functionality is preserved and some new tests added.