### PR TITLE
Don't fail on `nil` `failure.body`

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -60,7 +60,9 @@ puts [
 failures.each do |failure|
   puts "<details>"
   puts "<summary><code>#{failure.name} in #{failure.classname}</code></summary>\n\n"
-  puts "<code><pre>#{failure.body.chomp.strip}</pre></code>\n\n"
+  if failure.body
+    puts "<code><pre>#{failure.body.chomp.strip}</pre></code>\n\n"
+  end
   if failure.job
     puts "in <a href=\"##{failure.job}\">Job ##{failure.job}</a>"
   end

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -298,4 +298,23 @@ describe "Junit annotate plugin parser" do
 
     assert_equal 0, status.exitstatus
   end
+
+  it "handles empty failure bodies" do
+    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/empty-failure-body/")
+
+    assert_equal <<~OUTPUT, output
+      Parsing junit.xml
+      --- ❓ Checking failures
+      There is 1 failure/error 😭
+      --- ✍️ Preparing annotation
+      1 failure:
+
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+
+      </details>
+    OUTPUT
+
+    assert_equal 0, status.exitstatus
+  end
 end

--- a/ruby/tests/empty-failure-body/junit.xml
+++ b/ruby/tests/empty-failure-body/junit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="rspec" tests="2" skipped="0" failures="0" errors="1" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127">
+    <failure message=" expected: 250 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError"></failure>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
There are times that a failure's body is completely empty. In these cases, `failure.body` is `nil` and `chomp`/`strip` fail.

Please let me know if you have any feedback, or if there's anything else I can do to get this merged :)