### PR TITLE
Actually pass the failure output env var to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ cd ruby
 rake
 ```
 
+To test your plugin in your builds prior to opening a pull request, you can refer to your fork and SHA from a branch in your `pipeline.yml`.
+
+```
+steps:
+  - label: Annotate
+    plugins:
+      YourGithubHandle/junit-annotate#sha:
+        ...
+```
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -30,6 +30,7 @@ docker \
     --volume "$artifacts_dir:/junits" \
     --volume "$PLUGIN_DIR/ruby:/src" \
     --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" \
+    --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}" \
     ruby:2.5-alpine /src/bin/annotate /junits \
       > "$annotation_path"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -33,6 +33,34 @@ load "$BATS_PATH/load.bash"
   unstub docker
 }
 
+@test "can pass through optional params" {
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN="custom_(*)_pattern.xml"
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT="file"
+
+  artifacts_tmp="tests/tmp/$PWD/junit-artifacts"
+  annotation_tmp="tests/tmp/$PWD/junit-annotation"
+
+  stub mktemp \
+    "-d junit-annotate-plugin-artifacts-tmp.XXXXXXXXXX : mkdir -p $artifacts_tmp; echo $artifacts_tmp" \
+    "-d junit-annotate-plugin-annotation-tmp.XXXXXXXXXX : mkdir -p $annotation_tmp; echo $annotation_tmp"
+
+  stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
+                       "annotate --context junit --style error : echo Annotation added"
+
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}" ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+
+  assert_output --partial "Annotation added"
+
+  unstub mktemp
+  unstub buildkite-agent
+  unstub docker
+}
+
 @test "doesn't create annotation unless there's failures" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -35,8 +35,6 @@ load "$BATS_PATH/load.bash"
 
 @test "can pass through optional params" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
-  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN="custom_(*)_pattern.xml"
-  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT="file"
 
   artifacts_tmp="tests/tmp/$PWD/junit-artifacts"
   annotation_tmp="tests/tmp/$PWD/junit-annotation"
@@ -48,7 +46,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}" ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=custom_(*)_pattern.xml --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=file ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 
   run "$PWD/hooks/command"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -20,7 +20,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT= ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}' --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}' ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 
   run "$PWD/hooks/command"
 
@@ -35,6 +35,8 @@ load "$BATS_PATH/load.bash"
 
 @test "can pass through optional params" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN="custom_(*)_pattern.xml"
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT="file"
 
   artifacts_tmp="tests/tmp/$PWD/junit-artifacts"
   annotation_tmp="tests/tmp/$PWD/junit-annotation"
@@ -46,7 +48,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=custom_(*)_pattern.xml --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=file ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}' --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}' ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 
   run "$PWD/hooks/command"
 
@@ -71,7 +73,7 @@ load "$BATS_PATH/load.bash"
 
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT= ruby:2.5-alpine /src/bin/annotate /junits : echo No test errors"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}' --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}' ruby:2.5-alpine /src/bin/annotate /junits : echo No test errors"
 
   run "$PWD/hooks/command"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -20,7 +20,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT= ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 
   run "$PWD/hooks/command"
 
@@ -45,7 +45,7 @@ load "$BATS_PATH/load.bash"
 
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= ruby:2.5-alpine /src/bin/annotate /junits : echo No test errors"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT= ruby:2.5-alpine /src/bin/annotate /junits : echo No test errors"
 
   run "$PWD/hooks/command"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -20,7 +20,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}' --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}' ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT= ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 
   run "$PWD/hooks/command"
 
@@ -48,7 +48,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}' --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}' ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN='custom_(*)_pattern.xml' --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT='file' ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 
   run "$PWD/hooks/command"
 
@@ -73,7 +73,7 @@ load "$BATS_PATH/load.bash"
 
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}' --env 'BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT:-}' ruby:2.5-alpine /src/bin/annotate /junits : echo No test errors"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_OUTPUT= ruby:2.5-alpine /src/bin/annotate /junits : echo No test errors"
 
   run "$PWD/hooks/command"
 
@@ -82,4 +82,12 @@ load "$BATS_PATH/load.bash"
   unstub mktemp
   unstub buildkite-agent
   unstub docker
+}
+
+@test "errors without the 'artifacts' property set" {
+  run "$PWD/hooks/command"
+
+  assert_failure
+
+  assert_output --partial "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS: unbound variable"
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin/pull/32 so that the new plugin option is actually passed through to the docker container in which it's run.