### PR TITLE
Add fail-build-on-error property

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ There are two options for this:
 * `file`
   * displays: `MyClass::UnderTest text of the failed expectation in path/to/my_class/under_test.file_ext`
 
+### `fail-build-on-error` (optional)  
+Default: `false`
+
+If this setting is true and any errors are found in the JUnit XML files during
+parsing, the annotation step will exit with a non-zero value, which should cause 
+the build to fail.
+
 ## Developing
 
 To test the junit parser (in Ruby) and plugin hooks (in Bash):

--- a/hooks/command
+++ b/hooks/command
@@ -40,4 +40,10 @@ if grep -q "<details>" "$annotation_path"; then
   echo "--- :buildkite: Creating annotation"
   # shellcheck disable=SC2002
   cat "$annotation_path" | buildkite-agent annotate --context junit --style error
+
+  if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR:-false}" =~ (true|on|1) ]]
+  then
+    echo "--- :boom: Failing build due to error"
+    exit 1
+  fi
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,6 +14,8 @@ configuration:
       enum:
         - classname
         - file
+    fail-build-on-error:
+      type: boolean
   required:
     - artifacts
   additionalProperties: false


### PR DESCRIPTION
Certain test runners (e.g. the SalesForce DX [Apex test runner](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_apex.htm)) will not necessarily return a non-zero value when they encounter failing tests. This means that a build can pass with failing tests. If we are already using this plugin to annotate failing tests when we see them, we might as well hook into it to allow ourselves to fail the build then as well.