### PR TITLE
Use innerhtml instead of getting text inside failure and error tags

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'rexml/document'
-require "rexml/element"
+require 'rexml/element'
 
 # Adapted from https://stackoverflow.com/a/25888239/759019
 class REXML::Element

--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -1,6 +1,36 @@
 #!/usr/bin/env ruby
 
 require 'rexml/document'
+require "rexml/element"
+
+# Adapted from https://stackoverflow.com/a/25888239/759019
+class REXML::Element
+  def innerHTML=(xml)
+    require "rexml/document"
+    self.to_a.each do |e|
+      self.delete e
+    end
+    d = REXML::Document.new "<root>#{xml}</root>"
+    d.root.to_a.each do |e|
+      case e
+      when REXML::Text
+        self.add_text e
+      when REXML::Element
+        self.add_element e
+      else
+        puts "ERROR"
+      end
+    end
+    xml
+  end
+  def inner_html
+    ret = ''
+    self.to_a.each do |e|
+      ret += e.to_s
+    end
+    ret
+  end
+end
 
 # Reads a list of junit files and returns a nice Buildkite build annotation on
 # STDOUT that summarizes any failures.
@@ -33,10 +63,10 @@ junit_report_files.sort.each do |file|
     name = testcase.attributes['name'].to_s
     failed_test = testcase.attributes[failure_format].to_s
     testcase.elements.each("failure") do |failure|
-      failures << Failure.new(name, failed_test, failure.text, job, :failure)
+      failures << Failure.new(name, failed_test, failure.inner_html, job, :failure)
     end
     testcase.elements.each("error") do |error|
-      failures << Failure.new(name, failed_test, error.text, job, :error)
+      failures << Failure.new(name, failed_test, error.inner_html, job, :error)
     end
   end
 end

--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -3,35 +3,6 @@
 require 'rexml/document'
 require 'rexml/element'
 
-# Adapted from https://stackoverflow.com/a/25888239/759019
-class REXML::Element
-  def innerHTML=(xml)
-    require "rexml/document"
-    self.to_a.each do |e|
-      self.delete e
-    end
-    d = REXML::Document.new "<root>#{xml}</root>"
-    d.root.to_a.each do |e|
-      case e
-      when REXML::Text
-        self.add_text e
-      when REXML::Element
-        self.add_element e
-      else
-        puts "ERROR"
-      end
-    end
-    xml
-  end
-  def inner_html
-    ret = ''
-    self.to_a.each do |e|
-      ret += e.to_s
-    end
-    ret
-  end
-end
-
 # Reads a list of junit files and returns a nice Buildkite build annotation on
 # STDOUT that summarizes any failures.
 
@@ -51,6 +22,16 @@ end
 junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"))
 failures = []
 
+def text_content(element)
+  # Handle mulptiple CDATA/text children elements
+  text = element.texts().map(&:value).join.strip
+  if text.empty?
+    nil
+  else
+    text
+  end
+end
+
 junit_report_files.sort.each do |file|
   next if File.directory?(file)
 
@@ -63,10 +44,10 @@ junit_report_files.sort.each do |file|
     name = testcase.attributes['name'].to_s
     failed_test = testcase.attributes[failure_format].to_s
     testcase.elements.each("failure") do |failure|
-      failures << Failure.new(name, failed_test, failure.inner_html, job, :failure)
+      failures << Failure.new(name, failed_test, text_content(failure), job, :failure)
     end
     testcase.elements.each("error") do |error|
-      failures << Failure.new(name, failed_test, error.inner_html, job, :error)
+      failures << Failure.new(name, failed_test, text_content(error), job, :error)
     end
   end
 end

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -406,4 +406,26 @@ describe "Junit annotate plugin parser" do
 
     assert_equal 0, status.exitstatus
   end
+
+  it "handles cdata formatted XML files" do
+    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/failure-with-cdata/")
+
+    assert_equal <<~OUTPUT, output
+      Parsing junit.xml
+      --- ❓ Checking failures
+      There is 1 failure/error 😭
+      --- ✍️ Preparing annotation
+      1 error:
+
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+
+      <code><pre>First line of failure output
+            Second line of failure output</pre></code>
+
+      </details>
+    OUTPUT
+
+    assert_equal 0, status.exitstatus
+  end
 end

--- a/ruby/tests/failure-with-cdata/junit.xml
+++ b/ruby/tests/failure-with-cdata/junit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="rspec" tests="2" skipped="0" failures="0" errors="1" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127">
+    <error message=" expected: 250 got: 500 (compared using eql?) " type="RSpec::Expectations::ExpectationNotMetError">
+      <![CDATA[First line of failure output]]>
+      <![CDATA[Second line of failure output]]>
+    </error>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
Using the `text` doesn't work when JUnit output has a CData tag inside it which in turn contains the error. This allows it to work in that case and should be a nop in other cases.