### PR TITLE
Add testcase count to output

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -20,6 +20,7 @@ class Failure < Struct.new(:name, :failed_test, :body, :job, :type)
 end
 
 junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"))
+testcases = 0
 failures = []
 
 def text_content(element)
@@ -41,6 +42,7 @@ junit_report_files.sort.each do |file|
   doc = REXML::Document.new(xml)
 
   REXML::XPath.each(doc, '//testsuite//testcase') do |testcase|
+    testcases += 1
     name = testcase.attributes['name'].to_s
     failed_test = testcase.attributes[failure_format].to_s
     testcase.elements.each("failure") do |failure|
@@ -53,6 +55,7 @@ junit_report_files.sort.each do |file|
 end
 
 STDERR.puts "--- ❓ Checking failures"
+STDERR.puts "#{testcases} testcases found"
 
 if failures.empty?
   STDERR.puts "There were no failures/errors 🙌"

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -10,6 +10,7 @@ describe "Junit annotate plugin parser" do
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ❓ Checking failures
+      8 testcases found
       There were no failures/errors 🙌
     OUTPUT
 
@@ -24,6 +25,7 @@ describe "Junit annotate plugin parser" do
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ❓ Checking failures
+      6 testcases found
       There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
       4 failures:
@@ -108,6 +110,7 @@ describe "Junit annotate plugin parser" do
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ❓ Checking failures
+      6 testcases found
       There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
       2 failures and 2 errors:
@@ -190,6 +193,7 @@ describe "Junit annotate plugin parser" do
     assert_equal <<~OUTPUT, output
       Parsing junit-123-456-custom-pattern.xml
       --- ❓ Checking failures
+      2 testcases found
       There is 1 failure/error 😭
       --- ✍️ Preparing annotation
       1 failure:
@@ -223,6 +227,7 @@ describe "Junit annotate plugin parser" do
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ❓ Checking failures
+      6 testcases found
       There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
       2 failures and 2 errors:
@@ -307,6 +312,7 @@ describe "Junit annotate plugin parser" do
       Parsing sub-dir/junit-2.xml
       Parsing sub-dir/junit-3.xml
       --- ❓ Checking failures
+      6 testcases found
       There are 4 failures/errors 😭
       --- ✍️ Preparing annotation
       4 failures:
@@ -389,6 +395,7 @@ describe "Junit annotate plugin parser" do
     assert_equal <<~OUTPUT, output
       Parsing junit.xml
       --- ❓ Checking failures
+      2 testcases found
       There is 1 failure/error 😭
       --- ✍️ Preparing annotation
       1 failure:
@@ -408,6 +415,7 @@ describe "Junit annotate plugin parser" do
     assert_equal <<~OUTPUT, output
       Parsing junit.xml
       --- ❓ Checking failures
+      2 testcases found
       There is 1 failure/error 😭
       --- ✍️ Preparing annotation
       1 error:


### PR DESCRIPTION
One of the features we like in Bamboo is the visibility of the test execution. We've had tooling issues cause some tests not to run, which reduces our confidence in our product.

This PR adds a summary of the number of testcases found in the Junit XML files.