### PR TITLE
Don't send annotations if they're too large for the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ the build to fail.
 
 ## Developing
 
-To test the junit parser (in Ruby) and plugin hooks (in Bash):
+To test the plugin hooks (in Bash) and the junit parser (in Ruby):
 
 ```bash
 docker-compose run --rm plugin &&
@@ -73,7 +73,7 @@ To test your plugin in your builds prior to opening a pull request, you can refe
 steps:
   - label: Annotate
     plugins:
-      - YourGithubHandle/junit-annotate#v1.5.1:
+      - YourGithubHandle/junit-annotate#v1.2.3:
           ...
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 PLUGIN_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)/.."
+MAX_SIZE=100 # in KB
 
 echo "--- :junit: Download the junits"
 
@@ -13,6 +14,12 @@ annotation_path="${annotation_dir}/annotation.md"
 function cleanup {
   rm -rf "${artifacts_dir}"
   rm -rf "${annotation_dir}"
+}
+
+function check_size {
+  local size_in_kb
+  size_in_kb=$(du -k "${annotation_path}" | cut -f 1)
+  [ "${size_in_kb}" -lt "${MAX_SIZE}" ]
 }
 
 trap cleanup EXIT
@@ -37,6 +44,12 @@ docker \
 cat "$annotation_path"
 
 if grep -q "<details>" "$annotation_path"; then
+
+  if ! check_size; then
+      echo "--- :hurtrealbad: Sorry, annotation is too big to publish"
+      exit 1
+  fi
+
   echo "--- :buildkite: Creating annotation"
   # shellcheck disable=SC2002
   cat "$annotation_path" | buildkite-agent annotate --context junit --style error

--- a/hooks/command
+++ b/hooks/command
@@ -46,8 +46,9 @@ cat "$annotation_path"
 if grep -q "<details>" "$annotation_path"; then
 
   if ! check_size; then
-      echo "--- :hurtrealbad: Sorry, annotation is too big to publish"
-      exit 1
+      echo "--- :warning: Failures too large to annotate"
+      echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+      exit 0
   fi
 
   echo "--- :buildkite: Creating annotation"


### PR DESCRIPTION
The API won't process annotations larger than 100KB, so it's better
to reply with an error message earlier.

This new PR replaces my previous PR, with code changes in the hook scripts.  Shellcheck 0.4.6 compliant and it's running in our main Java pipeline.