### PR TITLE
Parse message from errors and failures

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -16,7 +16,7 @@ job_pattern = '-(.*).xml' if !job_pattern || job_pattern.empty?
 failure_format = ENV['BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT']
 failure_format = 'classname' if !failure_format || failure_format.empty?
 
-class Failure < Struct.new(:name, :failed_test, :body, :job, :type)
+class Failure < Struct.new(:name, :failed_test, :body, :job, :type, :message)
 end
 
 junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"))
@@ -33,6 +33,16 @@ def text_content(element)
   end
 end
 
+def message_content(element)
+  # Handle empty attributes
+  message = element.attributes['message'];
+  if message.nil? || message.empty?
+    nil
+  else
+    message.to_s
+  end
+end
+
 junit_report_files.sort.each do |file|
   next if File.directory?(file)
 
@@ -46,10 +56,10 @@ junit_report_files.sort.each do |file|
     name = testcase.attributes['name'].to_s
     failed_test = testcase.attributes[failure_format].to_s
     testcase.elements.each("failure") do |failure|
-      failures << Failure.new(name, failed_test, text_content(failure), job, :failure)
+      failures << Failure.new(name, failed_test, text_content(failure), job, :failure, message_content(failure))
     end
     testcase.elements.each("error") do |error|
-      failures << Failure.new(name, failed_test, text_content(error), job, :error)
+      failures << Failure.new(name, failed_test, text_content(error), job, :error, message_content(error))
     end
   end
 end
@@ -77,6 +87,9 @@ puts [
 failures.each do |failure|
   puts "<details>"
   puts "<summary><code>#{failure.name} in #{failure.failed_test}</code></summary>\n\n"
+  if failure.message
+    puts "<p>#{failure.message.chomp.strip}</p>\n\n"
+  end
   if failure.body
     puts "<pre><code>#{failure.body.chomp.strip}</code></pre>\n\n"
   end

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -33,6 +33,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -50,6 +52,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
       
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 700
@@ -67,6 +71,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
       
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 700
@@ -84,6 +90,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -118,6 +126,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -135,6 +145,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
       
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 700
@@ -152,6 +164,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
       
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 700
@@ -169,6 +183,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -201,6 +217,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -235,6 +253,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in ./spec/models/account_spec.rb</code></summary>
 
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
 
         expected: 250
@@ -251,6 +271,8 @@ describe "Junit annotate plugin parser" do
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in ./spec/models/account_spec.rb</code></summary>
+
+      <p>expected: 700 got: 500 (compared using eql?)</p>
 
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
 
@@ -269,6 +291,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in ./spec/models/account_spec.rb</code></summary>
 
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
 
         expected: 700
@@ -285,6 +309,8 @@ describe "Junit annotate plugin parser" do
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in ./spec/models/account_spec.rb</code></summary>
+
+      <p>expected: 250 got: 500 (compared using eql?)</p>
 
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
 
@@ -320,6 +346,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -337,6 +365,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
       
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 700
@@ -354,6 +384,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ in spec.models.account_spec</code></summary>
       
+      <p>expected: 700 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 700
@@ -371,6 +403,8 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
       <pre><code>Failure/Error: expect(account.maximum_jobs_added_by_pipeline_changer).to eql(250)
       
         expected: 250
@@ -403,6 +437,38 @@ describe "Junit annotate plugin parser" do
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
 
+      <p>expected: 250 got: 500 (compared using eql?)</p>
+
+      </details>
+    OUTPUT
+
+    assert_equal 0, status.exitstatus
+  end
+
+  it "handles missing message attributes" do
+    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/missing-message-attribute/")
+
+    assert_equal <<~OUTPUT, output
+      Parsing junit.xml
+      --- ❓ Checking failures
+      4 testcases found
+      There are 3 failures/errors 😭
+      --- ✍️ Preparing annotation
+      1 failure and 2 errors:
+
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+
+      </details>
+      
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 100 by default in spec.models.account_spec</code></summary>
+      
+      </details>
+      
+      <details>
+      <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 50 by default in spec.models.account_spec</code></summary>
+
       </details>
     OUTPUT
 
@@ -422,6 +488,8 @@ describe "Junit annotate plugin parser" do
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+
+      <p>expected: 250 got: 500 (compared using eql?)</p>
 
       <pre><code>First line of failure output
             Second line of failure output</code></pre>

--- a/ruby/tests/missing-message-attribute/junit.xml
+++ b/ruby/tests/missing-message-attribute/junit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="rspec" tests="2" skipped="0" failures="0" errors="1" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127">
+    <failure type="RSpec::Expectations::ExpectationNotMetError"></failure>
+  </testcase>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 100 by default" file="./spec/models/account_spec.rb" time="0.967127">
+    <error type="RSpec::Expectations::ExpectationNotMetError"></error>
+  </testcase>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 50 by default" file="./spec/models/account_spec.rb" time="0.967127">
+    <error message="" type="RSpec::Expectations::ExpectationNotMetError"></error>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
The message attribute in the [JUnit XML specification](https://www.ibm.com/support/knowledgecenter/en/SSUFAU_1.0.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html) contains useful information about a failure or error. This pull request is intended to surface this information inside a paragraph HTML element. This is made visible when the failure or error title is clicked inside the BuildKite annotation report.

Tests included.

Before in BuildKite:

<img width="753" alt="Without" src="https://user-images.githubusercontent.com/697029/60035826-a6940700-96a5-11e9-9007-d371cb34a69c.png">

After in BuildKite:

<img width="753" alt="with" src="https://user-images.githubusercontent.com/697029/60035834-a98ef780-96a5-11e9-8d57-86755daf301b.png">

Sample XML used:
```
<?xml version="1.0" encoding="UTF-8" ?>
<testsuites errors="1"
            failures="0"
            tests="1">
  <testsuite name="contingency.screenText"
    errors="1" failures="0" hostname="" id="" package="contingency" skipped="0"
    tests="1" time="122.1" timestamp="">
    <testcase name="contingency text" classname="contingency.screenText" time="122.1" assertions="0">
      <error message="Error while running &#34;waitForElementVisible&#34; command: Timed out while waiting for element &#34;input.loginButton&#34; with &#34;css selector&#34; to be present for 120000 milliseconds." type="error">NoSuchElementError: Error while running &#34;waitForElementVisible&#34; command: Timed out while waiting for element &#34;input.loginButton&#34; with &#34;css selector&#34; to be present for 120000 milliseconds.
    at WaitForElementVisible.noSuchElementError (/app/node_modules/nightwatch/lib/element/command.js:362:12)
    at WaitForElementVisible.elementNotFound (/app/node_modules/nightwatch/lib/api/element-commands/_waitForDisplayed.js:14:18)
    at Object.errorHandler (/app/node_modules/nightwatch/lib/api/element-commands/_waitForDisplayed.js:36:23)
    at PeriodicPromise.runAction (/app/node_modules/nightwatch/lib/util/periodic-promise.js:60:29)
    at process._tickCallback (internal/process/next_tick.js:68:7)</error>
    </testcase>
  </testsuite>
</testsuites>
```
