### PR TITLE
Work around script permission denied issue

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -38,7 +38,7 @@ docker \
     --volume "$PLUGIN_DIR/ruby:/src" \
     --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" \
     --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT:-}" \
-    ruby:2.5-alpine /src/bin/annotate /junits \
+    ruby:2.5-alpine ruby /src/bin/annotate /junits \
       > "$annotation_path"
 
 cat "$annotation_path"


### PR DESCRIPTION
When using docker in docker (in GKE), we were hitting a permission denied on executing the `annotate` ruby script directly. This resolved the issue for us in our CI environment.