### PR TITLE
Allow for custom annotation contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ If this setting is true and any errors are found in the JUnit XML files during
 parsing, the annotation step will exit with a non-zero value, which should cause 
 the build to fail.
 
+### `context` (optional)
+Default: `junit`
+
+The buildkite annotation context to use. Useful to differentiate multiple runs of this plugin in a single pipeline.
+
 ## Developing
 
 To test the plugin hooks (in Bash) and the junit parser (in Ruby):

--- a/hooks/command
+++ b/hooks/command
@@ -53,7 +53,7 @@ if grep -q "<details>" "$annotation_path"; then
 
   echo "--- :buildkite: Creating annotation"
   # shellcheck disable=SC2002
-  cat "$annotation_path" | buildkite-agent annotate --context junit --style error
+  cat "$annotation_path" | buildkite-agent annotate --context ${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT:-junit} --style error
 
   if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR:-false}" =~ (true|on|1) ]]
   then

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,8 @@ configuration:
         - file
     fail-build-on-error:
       type: boolean
+    context:
+      type: string
   required:
     - artifacts
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -65,6 +65,7 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN="custom_(*)_pattern.xml"
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT="file"
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR=false
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT="junit_custom_context"
 
   artifacts_tmp="tests/tmp/$PWD/junit-artifacts"
   annotation_tmp="tests/tmp/$PWD/junit-annotation"
@@ -74,7 +75,7 @@ load "$BATS_PATH/load.bash"
     "-d junit-annotate-plugin-annotation-tmp.XXXXXXXXXX : mkdir -p $annotation_tmp; echo $annotation_tmp"
 
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
-                       "annotate --context junit --style error : echo Annotation added"
+                       "annotate --context junit_custom_context --style error : echo Annotation added"
 
   stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN='custom_(*)_pattern.xml' --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT='file' ruby:2.5-alpine /src/bin/annotate /junits : echo '<details>Failure</details>'"
 


### PR DESCRIPTION
Enables multiple runs of the plugin in a pipeline

We had a use case similar to https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin/issues/67#issuecomment-461573758, and this allowed the two steps not to overwrite each other.