### PR TITLE
Allow junits_dir to match hidden files and dirs

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -20,7 +20,7 @@ failure_format = 'classname' if !failure_format || failure_format.empty?
 class Failure < Struct.new(:name, :failed_test, :body, :job, :type, :message)
 end
 
-junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"))
+junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"), File::FNM_DOTMATCH)
 testcases = 0
 failures = []
 

--- a/ruby/tests/.tests-in-hidden-dir/junit-1.xml
+++ b/ruby/tests/.tests-in-hidden-dir/junit-1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.020013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00" file="./spec/models/account_spec.rb" time="0.020013"/>
+</testsuite>

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -499,4 +499,17 @@ describe "Junit annotate plugin parser" do
 
     assert_equal 0, status.exitstatus
   end
+
+  it "handles junit dir paths with hidden directories" do
+    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/.tests-in-hidden-dir/")
+
+    assert_equal <<~OUTPUT, output
+      Parsing junit-1.xml
+      --- ❓ Checking failures
+      2 testcases found
+      There were no failures/errors 🙌
+    OUTPUT
+
+    assert_equal 0, status.exitstatus
+  end
 end


### PR DESCRIPTION
Hi! 👋 

Had a build pipeline that involved uploading files from directories nested within a hidden directory.

The artifact path is able to pick up hidden files and folders on upload and download, so I think the plugin should follow the same behaviour.

Hope everyone at buildkite is doing well.