### PR TITLE
Change <testcase> selector to only apply to direct descendants.

### DIFF
--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -52,7 +52,7 @@ junit_report_files.sort.each do |file|
   xml = File.read(file)
   doc = REXML::Document.new(xml)
 
-  REXML::XPath.each(doc, '//testsuite//testcase') do |testcase|
+  REXML::XPath.each(doc, '//testsuite/testcase') do |testcase|
     testcases += 1
     name = testcase.attributes['name'].to_s
     failed_test = testcase.attributes[failure_format].to_s


### PR DESCRIPTION
In the case where JUnit output contains nested `<testsuite>` entries the `//testsuite//testcase` selector retrieves multiple elements for each single `<testcase>`. This change causes the iterator to only process each test case entry once.

This was noticed when using the plugin with PHPUnit JUnit-compatible output.

## Example

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="" tests="10" assertions="100" errors="1" warnings="0" failures="0" skipped="0" time="3.14">
    <testsuite name="Unit-Tests" tests="10" assertions="100" errors="1" warnings="0" failures="0" skipped="0" time="3.14">
      <testsuite name="Tests\Unit\DemoUnitTest" file="/tests/Unit/DemoUnitTest.php" tests="5" assertions="3" errors="0" warnings="0" failures="0" skipped="0" time="0.767">
        <testcase name="testThisThing" class="Tests\Unit\DemoUnitTest" classname="Tests.Unit.DemoUnitTest" file="/tests/Unit/DemoUnitTest.php" line="19" assertions="1" time="0.105"/>
...
```