### PR TITLE
Report specified amount of slowest tests (0 by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The buildkite annotation context to use. Useful to differentiate multiple runs o
 ### `report-slowest` (optional)
 Default: `0`
 
-Adds a table with the specified amount of slowest tests listed in the JUnit XML files. The annotation will also be shown when all tests are successful.
+Include the specified number of slowest tests in the annotation. The annotation will always be shown.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Default: `junit`
 
 The buildkite annotation context to use. Useful to differentiate multiple runs of this plugin in a single pipeline.
 
+### `report-slowest` (optional)
+Default: `0`
+
+Adds a table with the specified amount of slowest tests listed in the JUnit XML files. The annotation will also be shown when all tests are successful.
+
 ## Developing
 
 To test the plugin hooks (in Bash) and the junit parser (in Ruby):

--- a/hooks/command
+++ b/hooks/command
@@ -58,8 +58,8 @@ cat "$annotation_path"
 
 if grep -q "<details>" "$annotation_path"; then
   if ! check_size; then
-    echo "--- :warning: Report too large to annotate"
-    echo "The report are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+    echo "--- :warning: Failures too large to annotate"
+    echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
   else
     echo "--- :buildkite: Creating annotation"
     # shellcheck disable=SC2002

--- a/hooks/command
+++ b/hooks/command
@@ -10,6 +10,8 @@ echo "--- :junit: Download the junits"
 artifacts_dir="$(pwd)/$(mktemp -d "junit-annotate-plugin-artifacts-tmp.XXXXXXXXXX")"
 annotation_dir="$(pwd)/$(mktemp -d "junit-annotate-plugin-annotation-tmp.XXXXXXXXXX")"
 annotation_path="${annotation_dir}/annotation.md"
+annotation_style="info"
+fail_build=0
 
 function cleanup {
   rm -rf "${artifacts_dir}"
@@ -30,6 +32,7 @@ buildkite-agent artifact download \
 
 echo "--- :junit: Processing the junits"
 
+set +e
 docker \
   --log-level "error" \
   run \
@@ -38,25 +41,35 @@ docker \
     --volume "$PLUGIN_DIR/ruby:/src" \
     --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" \
     --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT:-}" \
+    --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST:-}" \
     ruby:2.7-alpine ruby /src/bin/annotate /junits \
       > "$annotation_path"
+
+if [[ $? -eq 64 ]]; then # special exit code to signal test failures
+  annotation_style="error"
+  if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR:-false}" =~ (true|on|1) ]]; then
+    fail_build=1
+  fi
+fi
+
+set -e
 
 cat "$annotation_path"
 
 if grep -q "<details>" "$annotation_path"; then
-
   if ! check_size; then
-    echo "--- :warning: Failures too large to annotate"
-    echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+    echo "--- :warning: Report too large to annotate"
+    echo "The report are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
   else
     echo "--- :buildkite: Creating annotation"
     # shellcheck disable=SC2002
-    cat "$annotation_path" | buildkite-agent annotate --context "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT:-junit}" --style error
+    cat "$annotation_path" | buildkite-agent annotate --context "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT:-junit}" --style "$annotation_style"
   fi
+fi
 
-  if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR:-false}" =~ (true|on|1) ]]
-  then
-    echo "--- :boom: Failing build due to error"
-    exit 1
-  fi
+if ((fail_build)); then
+  echo "--- :boom: Failing build due to error"
+  exit 1
+else
+  exit 0
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,6 +18,8 @@ configuration:
       type: boolean
     context:
       type: string
+    report-slowest:
+      type: integer
   required:
     - artifacts
   additionalProperties: false

--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -17,12 +17,18 @@ job_pattern = '-(.*).xml' if !job_pattern || job_pattern.empty?
 failure_format = ENV['BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT']
 failure_format = 'classname' if !failure_format || failure_format.empty?
 
-class Failure < Struct.new(:name, :failed_test, :body, :job, :type, :message)
+report_slowest = ENV['BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST'].to_i
+
+class Failure < Struct.new(:name, :unit_name, :body, :job, :type, :message)
+end
+
+class Timing < Struct.new(:name, :unit_name, :time)
 end
 
 junit_report_files = Dir.glob(File.join(junits_dir, "**", "*"))
 testcases = 0
 failures = []
+timings = []
 
 def text_content(element)
   # Handle mulptiple CDATA/text children elements
@@ -55,48 +61,65 @@ junit_report_files.sort.each do |file|
   REXML::XPath.each(doc, '//testsuite/testcase') do |testcase|
     testcases += 1
     name = testcase.attributes['name'].to_s
-    failed_test = testcase.attributes[failure_format].to_s
+    unit_name = testcase.attributes[failure_format].to_s
+    time = testcase.attributes['time'].to_f
+    timings << Timing.new(name, unit_name, time)
     testcase.elements.each("failure") do |failure|
-      failures << Failure.new(name, failed_test, text_content(failure), job, :failure, message_content(failure))
+      failures << Failure.new(name, unit_name, text_content(failure), job, :failure, message_content(failure))
     end
     testcase.elements.each("error") do |error|
-      failures << Failure.new(name, failed_test, text_content(error), job, :error, message_content(error))
+      failures << Failure.new(name, unit_name, text_content(error), job, :error, message_content(error))
     end
   end
-end
-
-STDERR.puts "--- ❓ Checking failures"
-STDERR.puts "#{testcases} testcases found"
-
-if failures.empty?
-  STDERR.puts "There were no failures/errors 🙌"
-  exit 0
-else
-  STDERR.puts "There #{failures.length == 1 ? "is 1 failure/error" : "are #{failures.length} failures/errors" } 😭"
 end
 
 STDERR.puts "--- ✍️ Preparing annotation"
+STDERR.puts "#{testcases} testcases found"
 
-failures_count = failures.select {|f| f.type == :failure }.length
-errors_count = failures.select {|f| f.type == :error }.length
+if failures.any?
+  STDERR.puts "There #{failures.length == 1 ? "is 1 failure/error" : "are #{failures.length} failures/errors" } 😭"
 
-puts [
-  failures_count == 0 ? nil : (failures_count == 1 ? "1 failure" : "#{failures_count} failures"),
-  errors_count === 0 ? nil : (errors_count == 1 ? "1 error" : "#{errors_count} errors"),
-].compact.join(" and ") + ":\n\n"
+  failures_count = failures.select {|f| f.type == :failure }.length
+  errors_count = failures.select {|f| f.type == :error }.length
+  puts [
+    failures_count == 0 ? nil : (failures_count == 1 ? "1 failure" : "#{failures_count} failures"),
+    errors_count === 0 ? nil : (errors_count == 1 ? "1 error" : "#{errors_count} errors"),
+  ].compact.join(" and ") + ":\n\n"
 
-failures.each do |failure|
-  puts "<details>"
-  puts "<summary><code>#{failure.name} in #{failure.failed_test}</code></summary>\n\n"
-  if failure.message
-    puts "<p>#{failure.message.chomp.strip}</p>\n\n"
+  failures.each do |failure|
+    puts "<details>"
+    puts "<summary><code>#{failure.name} in #{failure.unit_name}</code></summary>\n\n"
+    if failure.message
+      puts "<p>#{failure.message.chomp.strip}</p>\n\n"
+    end
+    if failure.body
+      puts "<pre><code>#{CGI.escapeHTML(failure.body.chomp.strip)}</code></pre>\n\n"
+    end
+    if failure.job
+      puts "in <a href=\"##{failure.job}\">Job ##{failure.job}</a>"
+    end
+    puts "</details>"
+    puts "" unless failure == failures.last
   end
-  if failure.body
-    puts "<pre><code>#{CGI.escapeHTML(failure.body.chomp.strip)}</code></pre>\n\n"
-  end
-  if failure.job
-    puts "in <a href=\"##{failure.job}\">Job ##{failure.job}</a>"
-  end
-  puts "</details>"
-  puts "" unless failure == failures.last
+
+else
+  STDERR.puts "There were no failures/errors 🙌"
 end
+
+if report_slowest > 0
+  STDERR.puts "Reporting slowest tests ⏱"
+
+  puts "<details>"
+  puts "<summary>#{report_slowest} slowest tests</summary>\n\n"
+  puts "<table>"
+  puts "<thead><tr><th>Unit</th><th>Test</th><th>Time</th></tr></thead>"
+  puts "<tbody>"
+  timings.sort_by(&:time).reverse.take(report_slowest).each do |timing|
+    puts "<tr><td>#{timing.unit_name}</td><td>#{timing.name}</td><td>#{timing.time}</td></tr>"
+  end
+  puts "</tbody>"
+  puts "</table>"
+  puts "</details>"
+end
+
+exit 64 if failures.any? # special exit code to signal test failures

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -9,7 +9,7 @@ describe "Junit annotate plugin parser" do
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       8 testcases found
       There were no failures/errors 🙌
     OUTPUT
@@ -24,10 +24,9 @@ describe "Junit annotate plugin parser" do
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       6 testcases found
       There are 4 failures/errors 😭
-      --- ✍️ Preparing annotation
       4 failures:
       
       <details>
@@ -107,7 +106,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "handles failures and errors across multiple files" do
@@ -117,10 +116,9 @@ describe "Junit annotate plugin parser" do
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       6 testcases found
       There are 4 failures/errors 😭
-      --- ✍️ Preparing annotation
       2 failures and 2 errors:
       
       <details>
@@ -200,7 +198,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "accepts custom regex filename patterns for job id" do
@@ -208,10 +206,9 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit-123-456-custom-pattern.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       2 testcases found
       There is 1 failure/error 😭
-      --- ✍️ Preparing annotation
       1 failure:
       
       <details>
@@ -234,7 +231,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "uses the file path instead of classname for annotation content when specified" do
@@ -244,10 +241,9 @@ describe "Junit annotate plugin parser" do
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       6 testcases found
       There are 4 failures/errors 😭
-      --- ✍️ Preparing annotation
       2 failures and 2 errors:
 
       <details>
@@ -327,7 +323,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "handles failures across multiple files in sub dirs" do
@@ -337,10 +333,9 @@ describe "Junit annotate plugin parser" do
       Parsing sub-dir/junit-1.xml
       Parsing sub-dir/junit-2.xml
       Parsing sub-dir/junit-3.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       6 testcases found
       There are 4 failures/errors 😭
-      --- ✍️ Preparing annotation
       4 failures:
       
       <details>
@@ -420,7 +415,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "handles empty failure bodies" do
@@ -428,10 +423,9 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       2 testcases found
       There is 1 failure/error 😭
-      --- ✍️ Preparing annotation
       1 failure:
 
       <details>
@@ -442,7 +436,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "handles missing message attributes" do
@@ -450,10 +444,9 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       4 testcases found
       There are 3 failures/errors 😭
-      --- ✍️ Preparing annotation
       1 failure and 2 errors:
 
       <details>
@@ -472,7 +465,7 @@ describe "Junit annotate plugin parser" do
       </details>
     OUTPUT
 
-    assert_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
   end
 
   it "handles cdata formatted XML files" do
@@ -480,10 +473,9 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       2 testcases found
       There is 1 failure/error 😭
-      --- ✍️ Preparing annotation
       1 error:
 
       <details>
@@ -494,6 +486,36 @@ describe "Junit annotate plugin parser" do
       <pre><code>First line of failure output
             Second line of failure output</code></pre>
 
+      </details>
+    OUTPUT
+
+    assert_equal 64, status.exitstatus
+  end
+
+  it "reports specified amount of slowest tests" do
+    output, status = Open3.capture2e("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=5", "#{__dir__}/../bin/annotate", "#{__dir__}/no-test-failures/")
+
+    assert_equal <<~OUTPUT, output
+      Parsing junit-1.xml
+      Parsing junit-2.xml
+      Parsing junit-3.xml
+      --- ✍️ Preparing annotation
+      8 testcases found
+      There were no failures/errors 🙌
+      Reporting slowest tests ⏱
+      <details>
+      <summary>5 slowest tests</summary>
+
+      <table>
+      <thead><tr><th>Unit</th><th>Test</th><th>Time</th></tr></thead>
+      <tbody>
+      <tr><td>spec.models.account_spec</td><td>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default</td><td>0.977127</td></tr>
+      <tr><td>spec.models.account_spec</td><td>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default</td><td>0.967127</td></tr>
+      <tr><td>spec.models.account_spec</td><td>Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC</td><td>0.620013</td></tr>
+      <tr><td>spec.models.account_spec</td><td>Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00</td><td>0.520013</td></tr>
+      <tr><td>spec.models.account_spec</td><td>Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ</td><td>0.420013</td></tr>
+      </tbody>
+      </table>
       </details>
     OUTPUT
 

--- a/ruby/tests/no-test-failures/junit-1.xml
+++ b/ruby/tests/no-test-failures/junit-1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
-  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.020013"/>
-  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00" file="./spec/models/account_spec.rb" time="0.020013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.120013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00" file="./spec/models/account_spec.rb" time="0.220013"/>
 </testsuite>

--- a/ruby/tests/no-test-failures/junit-2.xml
+++ b/ruby/tests/no-test-failures/junit-2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
-  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
+  <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.320013"/>
   <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127"/>
 </testsuite>

--- a/ruby/tests/no-test-failures/junit-3.xml
+++ b/ruby/tests/no-test-failures/junit-3.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
-    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.020013"/>
-    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00" file="./spec/models/account_spec.rb" time="0.020013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 700 if the account is XYZ" file="./spec/models/account_spec.rb" time="0.420013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 900 if the account is F00" file="./spec/models/account_spec.rb" time="0.520013"/>
   </testsuite>
   <testsuite name="rspec" tests="2" skipped="0" failures="0" errors="0" time="49.290713" timestamp="2018-04-18T23:29:42+00:00" hostname="626d214475e4">
-    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.020013"/>
-    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.967127"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 500 if the account is ABC" file="./spec/models/account_spec.rb" time="0.620013"/>
+    <testcase classname="spec.models.account_spec" name="Account#maximum_jobs_added_by_pipeline_changer returns 250 by default" file="./spec/models/account_spec.rb" time="0.977127"/>
   </testsuite>
 </testsuites>

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -142,7 +142,7 @@ load "$BATS_PATH/load.bash"
 
   assert_success
 
-  assert_output --partial "Report too large to annotate"
+  assert_output --partial "Failures too large to annotate"
 
   unstub docker
   unstub buildkite-agent
@@ -172,7 +172,7 @@ load "$BATS_PATH/load.bash"
 
   assert_failure
 
-  assert_output --partial "Report too large to annotate"
+  assert_output --partial "Failures too large to annotate"
 
   unstub mktemp
   unstub buildkite-agent

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -22,7 +22,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>' && exit 64"
 
   run "$PWD/hooks/command"
 
@@ -49,7 +49,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>' && exit 64"
 
   run "$PWD/hooks/command"
 
@@ -77,7 +77,7 @@ load "$BATS_PATH/load.bash"
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts" \
                        "annotate --context junit_custom_context --style error : echo Annotation added"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN='custom_(*)_pattern.xml' --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT='file' ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN='custom_(*)_pattern.xml' --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT='file' --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>' && exit 64"
 
   run "$PWD/hooks/command"
 
@@ -102,7 +102,7 @@ load "$BATS_PATH/load.bash"
 
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo No test errors"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo No test errors"
 
   run "$PWD/hooks/command"
 
@@ -136,13 +136,13 @@ load "$BATS_PATH/load.bash"
 
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>' && exit 64"
 
   run "$PWD/hooks/command"
 
   assert_success
 
-  assert_output --partial "Failures too large to annotate"
+  assert_output --partial "Report too large to annotate"
 
   unstub docker
   unstub buildkite-agent
@@ -166,13 +166,13 @@ load "$BATS_PATH/load.bash"
   
   stub buildkite-agent "artifact download junits/*.xml /plugin/tests/tmp//plugin/junit-artifacts : echo Downloaded artifacts"
 
-  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>'"
+  stub docker "--log-level error run --rm --volume /plugin/tests/tmp//plugin/junit-artifacts:/junits --volume /plugin/hooks/../ruby:/src --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT= --env BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST= ruby:2.7-alpine ruby /src/bin/annotate /junits : echo '<details>Failure</details>' && exit 64"
 
   run "$PWD/hooks/command"
 
   assert_failure
 
-  assert_output --partial "Failures too large to annotate"
+  assert_output --partial "Report too large to annotate"
 
   unstub mktemp
   unstub buildkite-agent


### PR DESCRIPTION
With this feature you can specify `report-slowest` with the number of slowest test cases you want to see (as a table.) It took some minor refactoring to also produce the annotation (with style 'info') when no tests failed (including a special exit code.) Aside from some small changes to the logging output there's no change in functionality without the new option.