### PR TITLE
Update failing assertion in annotate test

### DIFF
--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -527,7 +527,7 @@ describe "Junit annotate plugin parser" do
 
     assert_equal <<~OUTPUT, output
       Parsing junit-1.xml
-      --- ❓ Checking failures
+      --- ✍️ Preparing annotation
       2 testcases found
       There were no failures/errors 🙌
     OUTPUT


### PR DESCRIPTION
The failing test and code for it was merged long after the [initial PR](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin/pull/139), as a result the assertion for the test needs to be updated to accommodate a later change in how annotation messages are printed.