### PR TITLE
Add an annotation when report is too large

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -59,7 +59,9 @@ cat "$annotation_path"
 if grep -q "<details>" "$annotation_path"; then
   if ! check_size; then
     echo "--- :warning: Failures too large to annotate"
-    echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+    msg="The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+    echo "$msg"
+    echo "$msg" | buildkite-agent annotate --context "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT:-junit}" --style "$annotation_style"
   else
     echo "--- :buildkite: Creating annotation"
     # shellcheck disable=SC2002


### PR DESCRIPTION
This would at least give people a clue as to why there were no annotations but the tests failed.