### PR TITLE
Test summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The artifact glob path to find the JUnit XML files.
 
 Example: `tmp/junit-*.xml`
 
-### `allways-annotate` (optional, boolean)
+### `always-annotate` (optional, boolean)
 
 Forces the creation of the annotation even when no failures or errors are found
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The artifact glob path to find the JUnit XML files.
 
 Example: `tmp/junit-*.xml`
 
+### `allways-annotate` (optional, boolean)
+
+Forces the creation of the annotation even when no failures or errors are found
+
 ### `job-uuid-file-pattern` (optional)
 Default: `-(.*).xml`
 

--- a/hooks/command
+++ b/hooks/command
@@ -15,6 +15,8 @@ annotation_dir="$(pwd)/$(mktemp -d "junit-annotate-plugin-annotation-tmp.XXXXXXX
 annotation_path="${annotation_dir}/annotation.md"
 annotation_style="info"
 fail_build=0
+has_errors=0
+create_annotation=0
 
 function cleanup {
   rm -rf "${artifacts_dir}"
@@ -54,8 +56,11 @@ exit_code=$?
 set -e
 
 if [[ $exit_code -eq 64 ]]; then # special exit code to signal test failures
+  has_errors=1
+  create_annotation=1
   annotation_style="error"
   if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR:-false}" =~ (true|on|1) ]]; then
+    echo "--- :boom: Build will fail due to errors being found"
     fail_build=1
   fi
 elif [[ $exit_code -ne 0 ]]; then
@@ -65,21 +70,21 @@ fi
 
 cat "$annotation_path"
 
-if grep -q "<details>" "$annotation_path"; then
-  if ! check_size; then
-    echo "--- :warning: Failures too large to annotate"
-    msg="The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
-    echo "$msg"
-  else
-    echo "--- :buildkite: Creating annotation"
-    # shellcheck disable=SC2002
-    cat "$annotation_path" | buildkite-agent annotate --context "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT:-junit}" --style "$annotation_style"
+if [ $has_errors -eq 0 ]; then
+  # done in nested if to simplify outer conditions
+  if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ALWAYS_ANNOTATE:-false}" =~ (true|on|1) ]]; then
+    create_annotation=1
   fi
+elif ! check_size; then
+  echo "--- :warning: Failures too large to annotate"
+  echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+  create_annotation=0
 fi
 
-if ((fail_build)); then
-  echo "--- :boom: Failing build due to error"
-  exit 1
-else
-  exit 0
+if [ $create_annotation -ne 0 ]; then
+  echo "--- :buildkite: Creating annotation"
+  # shellcheck disable=SC2002
+  cat "$annotation_path" | buildkite-agent annotate --context "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTEXT:-junit}" --style "$annotation_style"
 fi
+
+exit $fail_build

--- a/hooks/command
+++ b/hooks/command
@@ -78,8 +78,19 @@ if [ $has_errors -eq 0 ]; then
   fi
 elif ! check_size; then
   echo "--- :warning: Failures too large to annotate"
-  echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
-  create_annotation=0
+
+  # creating a simplified version of the annotation
+  mv "${annotation_path}" "${annotation_path}2"
+  head -4 "${annotation_path}2" >"${annotation_path}"
+  # || true is to avoid issues if no summary is found
+  grep '<summary>' "${annotation_path}2" >>"${annotation_path}" || true
+
+  if ! check_size; then
+    echo "The failures are too large to create a build annotation. Please inspect the failed JUnit artifacts manually."
+    create_annotation=0
+  else
+    echo "The failures are too large to create complete annotation, using a simplified annotation"
+  fi
 fi
 
 if [ $create_annotation -ne 0 ]; then

--- a/hooks/command
+++ b/hooks/command
@@ -73,6 +73,7 @@ cat "$annotation_path"
 if [ $has_errors -eq 0 ]; then
   # done in nested if to simplify outer conditions
   if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ALWAYS_ANNOTATE:-false}" =~ (true|on|1) ]]; then
+    echo "Will create annotation anyways"
     create_annotation=1
   fi
 elif ! check_size; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,7 +7,7 @@ configuration:
   properties:
     artifacts:
       type: string
-    allways-annotate:
+    always-annotate:
       type: boolean
     context:
       type: string

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,6 +7,8 @@ configuration:
   properties:
     artifacts:
       type: string
+    allways-annotate:
+      type: boolean
     context:
       type: string
     failure-format:

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,7 +7,7 @@ configuration:
   properties:
     artifacts:
       type: string
-    job-uuid-file-pattern:
+    context:
       type: string
     failure-format:
       type: string
@@ -16,7 +16,7 @@ configuration:
         - file
     fail-build-on-error:
       type: boolean
-    context:
+    job-uuid-file-pattern:
       type: string
     report-slowest:
       type: integer

--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -81,9 +81,9 @@ errors_count = failures.select {|f| f.type == :error }.length
 puts "Failures: #{failures_count}"
 puts "Errors: #{errors_count}"
 puts "Total tests: #{testcases}"
-puts "\n"
 
 failures.each do |failure|
+  puts ""
   puts "<details>"
   puts "<summary><code>#{failure.name} in #{failure.unit_name}</code></summary>\n\n"
   if failure.message
@@ -96,12 +96,11 @@ failures.each do |failure|
     puts "in <a href=\"##{failure.job}\">Job ##{failure.job}</a>"
   end
   puts "</details>"
-  puts "" unless failure == failures.last
 end
 
 if report_slowest > 0
   STDERR.puts "Reporting slowest tests ⏱"
-
+  puts ""
   puts "<details>"
   puts "<summary>#{report_slowest} slowest tests</summary>\n\n"
   puts "<table>"

--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -74,36 +74,29 @@ junit_report_files.sort.each do |file|
 end
 
 STDERR.puts "--- ✍️ Preparing annotation"
-STDERR.puts "#{testcases} testcases found"
 
-if failures.any?
-  STDERR.puts "There #{failures.length == 1 ? "is 1 failure/error" : "are #{failures.length} failures/errors" } 😭"
+failures_count = failures.select {|f| f.type == :failure }.length
+errors_count = failures.select {|f| f.type == :error }.length
 
-  failures_count = failures.select {|f| f.type == :failure }.length
-  errors_count = failures.select {|f| f.type == :error }.length
-  puts [
-    failures_count == 0 ? nil : (failures_count == 1 ? "1 failure" : "#{failures_count} failures"),
-    errors_count === 0 ? nil : (errors_count == 1 ? "1 error" : "#{errors_count} errors"),
-  ].compact.join(" and ") + ":\n\n"
+puts "Failures: #{failures_count}"
+puts "Errors: #{errors_count}"
+puts "Total tests: #{testcases}"
+puts "\n"
 
-  failures.each do |failure|
-    puts "<details>"
-    puts "<summary><code>#{failure.name} in #{failure.unit_name}</code></summary>\n\n"
-    if failure.message
-      puts "<p>#{failure.message.chomp.strip}</p>\n\n"
-    end
-    if failure.body
-      puts "<pre><code>#{CGI.escapeHTML(failure.body.chomp.strip)}</code></pre>\n\n"
-    end
-    if failure.job
-      puts "in <a href=\"##{failure.job}\">Job ##{failure.job}</a>"
-    end
-    puts "</details>"
-    puts "" unless failure == failures.last
+failures.each do |failure|
+  puts "<details>"
+  puts "<summary><code>#{failure.name} in #{failure.unit_name}</code></summary>\n\n"
+  if failure.message
+    puts "<p>#{failure.message.chomp.strip}</p>\n\n"
   end
-
-else
-  STDERR.puts "There were no failures/errors 🙌"
+  if failure.body
+    puts "<pre><code>#{CGI.escapeHTML(failure.body.chomp.strip)}</code></pre>\n\n"
+  end
+  if failure.job
+    puts "in <a href=\"##{failure.job}\">Job ##{failure.job}</a>"
+  end
+  puts "</details>"
+  puts "" unless failure == failures.last
 end
 
 if report_slowest > 0

--- a/ruby/tests/annotate_test.rb
+++ b/ruby/tests/annotate_test.rb
@@ -3,31 +3,38 @@ require 'open3'
 
 describe "Junit annotate plugin parser" do
   it "handles no failures" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/no-test-failures/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/no-test-failures/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ✍️ Preparing annotation
-      8 testcases found
-      There were no failures/errors 🙌
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 0
+      Errors: 0
+      Total tests: 8
     OUTPUT
 
     assert_equal 0, status.exitstatus
   end
 
   it "handles failures across multiple files" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/two-test-failures/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/two-test-failures/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ✍️ Preparing annotation
-      6 testcases found
-      There are 4 failures/errors 😭
-      4 failures:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 4
+      Errors: 0
+      Total tests: 6
       
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -110,17 +117,20 @@ describe "Junit annotate plugin parser" do
   end
 
   it "handles failures and errors across multiple files" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/test-failure-and-error/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/test-failure-and-error/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ✍️ Preparing annotation
-      6 testcases found
-      There are 4 failures/errors 😭
-      2 failures and 2 errors:
-      
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 2
+      Errors: 2
+      Total tests: 6
+
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
       
@@ -202,14 +212,17 @@ describe "Junit annotate plugin parser" do
   end
 
   it "accepts custom regex filename patterns for job id" do
-    output, status = Open3.capture2e("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=junit-(.*)-custom-pattern.xml", "#{__dir__}/../bin/annotate", "#{__dir__}/custom-job-uuid-pattern/")
+    stdout, stderr, status = Open3.capture3("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=junit-(.*)-custom-pattern.xml", "#{__dir__}/../bin/annotate", "#{__dir__}/custom-job-uuid-pattern/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-123-456-custom-pattern.xml
       --- ✍️ Preparing annotation
-      2 testcases found
-      There is 1 failure/error 😭
-      1 failure:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 1
+      Errors: 0
+      Total tests: 2
       
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -235,16 +248,19 @@ describe "Junit annotate plugin parser" do
   end
 
   it "uses the file path instead of classname for annotation content when specified" do
-    output, status = Open3.capture2e("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=file", "#{__dir__}/../bin/annotate", "#{__dir__}/test-failure-and-error/")
+    stdout, stderr, status = Open3.capture3("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=file", "#{__dir__}/../bin/annotate", "#{__dir__}/test-failure-and-error/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ✍️ Preparing annotation
-      6 testcases found
-      There are 4 failures/errors 😭
-      2 failures and 2 errors:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 2
+      Errors: 2
+      Total tests: 6
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in ./spec/models/account_spec.rb</code></summary>
@@ -327,16 +343,19 @@ describe "Junit annotate plugin parser" do
   end
 
   it "handles failures across multiple files in sub dirs" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/tests-in-sub-dirs/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/tests-in-sub-dirs/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing sub-dir/junit-1.xml
       Parsing sub-dir/junit-2.xml
       Parsing sub-dir/junit-3.xml
       --- ✍️ Preparing annotation
-      6 testcases found
-      There are 4 failures/errors 😭
-      4 failures:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 4
+      Errors: 0
+      Total tests: 6
       
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -419,14 +438,17 @@ describe "Junit annotate plugin parser" do
   end
 
   it "handles empty failure bodies" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/empty-failure-body/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/empty-failure-body/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit.xml
       --- ✍️ Preparing annotation
-      2 testcases found
-      There is 1 failure/error 😭
-      1 failure:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 1
+      Errors: 0
+      Total tests: 2
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -439,15 +461,18 @@ describe "Junit annotate plugin parser" do
     assert_equal 64, status.exitstatus
   end
 
-  it "handles missing message attributes" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/missing-message-attribute/")
+  it "handles miss message attributes" do
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/missing-message-attribute/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit.xml
       --- ✍️ Preparing annotation
-      4 testcases found
-      There are 3 failures/errors 😭
-      1 failure and 2 errors:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 1
+      Errors: 2
+      Total tests: 4
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -469,14 +494,17 @@ describe "Junit annotate plugin parser" do
   end
 
   it "handles cdata formatted XML files" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/failure-with-cdata/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/failure-with-cdata/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit.xml
       --- ✍️ Preparing annotation
-      2 testcases found
-      There is 1 failure/error 😭
-      1 error:
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 0
+      Errors: 1
+      Total tests: 2
 
       <details>
       <summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
@@ -493,16 +521,21 @@ describe "Junit annotate plugin parser" do
   end
 
   it "reports specified amount of slowest tests" do
-    output, status = Open3.capture2e("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=5", "#{__dir__}/../bin/annotate", "#{__dir__}/no-test-failures/")
+    stdout, stderr, status = Open3.capture3("env", "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=5", "#{__dir__}/../bin/annotate", "#{__dir__}/no-test-failures/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-1.xml
       Parsing junit-2.xml
       Parsing junit-3.xml
       --- ✍️ Preparing annotation
-      8 testcases found
-      There were no failures/errors 🙌
       Reporting slowest tests ⏱
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 0
+      Errors: 0
+      Total tests: 8
+      
       <details>
       <summary>5 slowest tests</summary>
 
@@ -523,13 +556,17 @@ describe "Junit annotate plugin parser" do
   end
 
   it "handles junit dir paths with hidden directories" do
-    output, status = Open3.capture2e("#{__dir__}/../bin/annotate", "#{__dir__}/.tests-in-hidden-dir/")
+    stdout, stderr, status = Open3.capture3("#{__dir__}/../bin/annotate", "#{__dir__}/.tests-in-hidden-dir/")
 
-    assert_equal <<~OUTPUT, output
+    assert_equal stderr, <<~OUTPUT
       Parsing junit-1.xml
       --- ✍️ Preparing annotation
-      2 testcases found
-      There were no failures/errors 🙌
+    OUTPUT
+
+    assert_equal stdout, <<~OUTPUT
+      Failures: 0
+      Errors: 0
+      Total tests: 2
     OUTPUT
 
     assert_equal 0, status.exitstatus

--- a/tests/2-tests-1-failure.output
+++ b/tests/2-tests-1-failure.output
@@ -1,0 +1,13 @@
+Failures: 0
+Errors: 1
+Total tests: 2
+
+<details>
+<summary><code>Account#maximum_jobs_added_by_pipeline_changer returns 250 by default in spec.models.account_spec</code></summary>
+
+<p>expected: 250 got: 500 (compared using eql?)</p>
+
+<pre><code>First line of failure output
+      Second line of failure output</code></pre>
+
+</details>

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -161,7 +161,7 @@ export annotation_input="tests/tmp/annotation.input"
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "No tests errors"
+  assert_output --partial "No test errors"
   assert_output --partial "Will create annotation anyways"
 
   unstub mktemp
@@ -178,7 +178,7 @@ export annotation_input="tests/tmp/annotation.input"
   refute_output --partial ":junit:"
 }
 
-@test "fails if the annotation is larger than 1MB" {
+@test "fails if the annotation is larger than 1MB even after summary" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
 
   stub mktemp \
@@ -187,7 +187,8 @@ export annotation_input="tests/tmp/annotation.input"
 
   # 1KB over the 1MB size limit of annotations
   stub du \
-    "-k \* : echo 1025 \$2"
+    "-k \* : echo 1025$'\t'\$2" \
+    "-k \* : echo 1025$'\t'\$2"
 
   stub buildkite-agent \
     "artifact download \* \* : echo Downloaded artifact \$3 to \$4"
@@ -200,6 +201,7 @@ export annotation_input="tests/tmp/annotation.input"
   assert_success
 
   assert_output --partial "Failures too large to annotate"
+  assert_output --partial "failures are too large to create a build annotation"
 
   unstub docker
   unstub du
@@ -207,6 +209,39 @@ export annotation_input="tests/tmp/annotation.input"
   unstub mktemp
 }
 
+@test "creates summary annotation if original is larger than 1MB" {
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
+
+  stub mktemp \
+    "-d \* : mkdir -p '$artifacts_tmp'; echo '$artifacts_tmp'" \
+    "-d \* : mkdir -p '$annotation_tmp'; echo '$annotation_tmp'"
+
+  # 1KB over the 1MB size limit of annotations
+  stub du \
+    "-k \* : echo 1025$'\t'\$2" \
+    "-k \* : echo 10$'\t'\$2"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo Downloaded artifact \$3 to \$4" \
+    "annotate --context \* --style \* : cat >'${annotation_input}'; echo Annotation added with context \$3 and style \$5, content saved"
+
+  stub docker \
+    "--log-level error run --rm --volume \* --volume \* --env \* --env \* --env \* ruby:2.7-alpine ruby /src/bin/annotate /junits : cat tests/2-tests-1-failure.output && exit 64"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+
+  assert_output --partial "Failures too large to annotate"
+  assert_output --partial "using a simplified annotation"
+  assert_equal "5 ${annotation_input}" "$(wc -l "${annotation_input}" | cut -f 1)"
+
+  unstub docker
+  unstub du
+  unstub buildkite-agent
+  unstub mktemp
+  rm "${annotation_input}"
+}
 
 @test "returns an error if fail-build-on-error is true" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
@@ -243,7 +278,8 @@ export annotation_input="tests/tmp/annotation.input"
 
   # 1KB over the 1MB size limit of annotations
   stub du \
-    "-k \* : echo 1025 \$2"
+    "-k \* : echo 1025$'\t'\$2" \
+    "-k \* : echo 1025$'\t'\$2"
   
   stub buildkite-agent \
     "artifact download \* \* : echo Downloaded artifact \$3 to \$4"


### PR DESCRIPTION
This PR has several related changes:
- changes the output of the plugin so that it always shows amount of errors, failures and total tests checked
- adds the option `always-annotate` to create the annotation even if no failures were found (closes #136)
- adds more logic to the annotation to reduce its size when it is over the limit (by only pasting the summary headings instead of all the details) (closes #168)

I also changed the flow of the hook to avoid a lot of code duplication and complicated conditional paths.

As I modified the output of the ruby code, I revamped the rake tests as well checking stdout and stderr separately