### PR TITLE
Attempting to fix issue 168

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Default: `0`
 
 Include the specified number of slowest tests in the annotation. The annotation will always be shown.
 
+### `max-failures-reported` (optional)
+Default: `0`
+
+Include the specified number of slowest tests in the annotation. The annotation will always be shown.
+
 ## Developing
 
 To test the plugin hooks (in Bash) and the junit parser (in Ruby):

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,6 +20,8 @@ configuration:
       type: string
     report-slowest:
       type: integer
+    max-failures-reported:
+      type: integer
   required:
     - artifacts
   additionalProperties: false

--- a/ruby/bin/annotate
+++ b/ruby/bin/annotate
@@ -19,6 +19,8 @@ failure_format = 'classname' if !failure_format || failure_format.empty?
 
 report_slowest = ENV['BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST'].to_i
 
+max_failures_reported = ENV['BUILDKITE_PLUGIN_JUNIT_ANNOTATE_MAX_FAILURES_REPORTED'].to_i
+
 class Failure < Struct.new(:name, :unit_name, :body, :job, :type, :message)
 end
 
@@ -85,7 +87,8 @@ if failures.any?
     failures_count == 0 ? nil : (failures_count == 1 ? "1 failure" : "#{failures_count} failures"),
     errors_count === 0 ? nil : (errors_count == 1 ? "1 error" : "#{errors_count} errors"),
   ].compact.join(" and ") + ":\n\n"
-
+  original_failure_length = failures.length
+  failures = failures.take(max_failures_reported) unless max_failures_reported == 0
   failures.each do |failure|
     puts "<details>"
     puts "<summary><code>#{failure.name} in #{failure.unit_name}</code></summary>\n\n"
@@ -100,6 +103,12 @@ if failures.any?
     end
     puts "</details>"
     puts "" unless failure == failures.last
+  end
+  if original_failure_length > max_failures_reported and max_failures_reported > 0
+    puts(
+      "\n#{original_failure_length - max_failures_reported} more failures/errors present, but unreported due to max " \
+      "failures reported value of #{max_failures_reported}"
+    )
   end
 
 else


### PR DESCRIPTION
Intoducing a new optional parameter `max-failures-reported` which allows folks to specify the max number of failures to include in the report before cutting it off. Included tests.