### PR TITLE
Allow builds to pass where test files might not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Example: `tmp/junit-*.xml`
 Forces the creation of the annotation even when no failures or errors are found
 
 ### `job-uuid-file-pattern` (optional)
+
 Default: `-(.*).xml`
 
 The regular expression (with capture group) that matches the job UUID in the junit file names. This is used to create the job links in the annotation.
@@ -38,32 +39,43 @@ The regular expression (with capture group) that matches the job UUID in the jun
 To use this, configure your test reporter to embed the `$BUILDKITE_JOB_ID` environment variable into your junit file names. For example `"junit-buildkite-job-$BUILDKITE_JOB_ID.xml"`.
 
 ### `failure-format` (optional)
+
 Default: `classname`
 
 This setting controls the format of your failed test in the main annotation summary.
 
 There are two options for this:
-* `classname`
-  * displays: `MyClass::UnderTest text of the failed expectation in path.to.my_class.under_test`
-* `file`
-  * displays: `MyClass::UnderTest text of the failed expectation in path/to/my_class/under_test.file_ext`
 
-### `fail-build-on-error` (optional)  
+- `classname`
+  - displays: `MyClass::UnderTest text of the failed expectation in path.to.my_class.under_test`
+- `file`
+  - displays: `MyClass::UnderTest text of the failed expectation in path/to/my_class/under_test.file_ext`
+
+### `fail-build-on-error` (optional)
+
 Default: `false`
 
 If this setting is true and any errors are found in the JUnit XML files during
-parsing, the annotation step will exit with a non-zero value, which should cause 
+parsing, the annotation step will exit with a non-zero value, which should cause
 the build to fail.
 
 ### `context` (optional)
+
 Default: `junit`
 
 The buildkite annotation context to use. Useful to differentiate multiple runs of this plugin in a single pipeline.
 
 ### `report-slowest` (optional)
+
 Default: `0`
 
 Include the specified number of slowest tests in the annotation. The annotation will always be shown.
+
+### `continue-without-junit-files` (optional)
+
+Default: `false`
+
+If this is set to `true` and test files are **not** found during download, the plugin will exit with a code of `0` and allow the build to continue, rather than marking the build as `failed` where test files are not found.
 
 ## Developing
 

--- a/hooks/command
+++ b/hooks/command
@@ -32,9 +32,17 @@ function check_size {
 trap cleanup EXIT
 
 echo "--- :junit: Download the junits"
+if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_CONTINUE_WITHOUT_JUNIT_FILES:-false}" =~ (true|on|1) ]]; then
+  echo "--- :boom: If no files are found, the build will continue."
+  fail_build=0
+else
+  echo "--- :boom: If no files are found, the build will fail."
+  fail_build=2
+fi
+
 if ! buildkite-agent artifact download "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS}" "$artifacts_dir"; then
   echo "--- :boom: Could not download artifacts"
-  exit 2
+  exit $fail_build
 fi
 
 echo "--- :junit: Processing the junits"

--- a/plugin.yml
+++ b/plugin.yml
@@ -22,6 +22,8 @@ configuration:
       type: string
     report-slowest:
       type: integer
+    continue-without-junit-files:
+      type: boolean
   required:
     - artifacts
   additionalProperties: false


### PR DESCRIPTION
Occasionally, test files might not exist but this might be an intended action. Rather than have to write a shell script to manually handle these cases, it might be handy to have that support built in to the plugin itself.