### PR TITLE
Failed download exit code customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
   - wait: ~
     continue_on_failure: true
   - plugins:
-      - junit-annotate#v2.2.0:
+      - junit-annotate#v2.4.0:
           artifacts: tmp/junit-*.xml
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Default: `false`
 
 If this setting is true and any errors are found in the JUnit XML files during parsing, the annotation step will exit with a non-zero value, which should cause the build to fail.
 
+### `failed-download-exit-code` (optional, integer)
+
+Default: `2`
+
+Exit code of the plugin if the call to `buildkite-agent artifact download` fails.
+
 ### `min-tests` (optional, integer)
 
 Minimum amount of run tests that need to be analyzed or a failure will be reported. It is useful to ensure that tests are actually run and report files to analyze do contain information.

--- a/hooks/command
+++ b/hooks/command
@@ -35,7 +35,7 @@ trap cleanup EXIT
 echo "--- :junit: Download the junits"
 if ! buildkite-agent artifact download "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS}" "$artifacts_dir"; then
   echo "--- :boom: Could not download artifacts"
-  exit 2
+  exit "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILED_DOWNLOAD_EXIT_CODE:-2}"
 fi
 
 echo "--- :junit: Processing the junits"

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,6 +18,8 @@ configuration:
         - file
     fail-build-on-error:
       type: boolean
+    failed-download-exit-code:
+      type: integer
     job-uuid-file-pattern:
       type: string
     min-tests:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -346,6 +346,27 @@ export annotation_input="tests/tmp/annotation.input"
   unstub buildkite-agent
 }
 
+@test "customize error when agent download fails" {
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILED_DOWNLOAD_EXIT_CODE=5
+
+  stub mktemp \
+    "-d \* : mkdir -p '$artifacts_tmp'; echo '$artifacts_tmp'" \
+    "-d \* : mkdir -p '$annotation_tmp'; echo '$annotation_tmp'"
+
+  stub buildkite-agent \
+    "artifact download \* \* : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure 5
+
+  assert_output --partial "Could not download artifacts"
+
+  unstub mktemp
+  unstub buildkite-agent
+}
+
 @test "creates annotation with no failures but min tests triggers" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_MIN_TESTS=1


### PR DESCRIPTION
Allow changing the exit code when the artifact download fails (should allow for better retry handling).

Another way of implementing #181 