### PR TITLE
Fix docker: invalid reference format

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -9,7 +9,7 @@ fi
 
 PLUGIN_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)/.."
 MAX_SIZE=1024 # in KB
-RUBY_IMAGE="${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_RUBY_IMAGE:-'ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca'}"
+RUBY_IMAGE="${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_RUBY_IMAGE:-ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca}"
 
 artifacts_dir="$(pwd)/$(mktemp -d "junit-annotate-plugin-artifacts-tmp.XXXXXXXXXX")"
 annotation_dir="$(pwd)/$(mktemp -d "junit-annotate-plugin-annotation-tmp.XXXXXXXXXX")"


### PR DESCRIPTION
**NOTE** I have not tested this _at all_. I don't actually use this plugin, but someone in our help channels reported it. Just wanted to get this up as a starting point. Please someone test this before merge

There looks to be an issue in the recent changes that are causing an invalid docker image to be referenced. I think this is because if an extra quote in an environment variable

Fixes #183