### PR TITLE
Update version number in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
   - wait: ~
     continue_on_failure: true
   - plugins:
-      - junit-annotate#v2.4.0:
+      - junit-annotate#v2.4.1:
           artifacts: tmp/junit-*.xml
 ```
 
@@ -104,7 +104,7 @@ To test your plugin in your builds prior to opening a pull request, you can refe
 steps:
   - label: Annotate
     plugins:
-      - YourGithubHandle/junit-annotate#v2.2.0:
+      - YourGithubHandle/junit-annotate#v2.4.1:
           ...
 ```
 


### PR DESCRIPTION
Update version number to 2.4.1 in examples in ReadMe, after the bugFix https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin/issues/183