### PR TITLE
Corrected shellcheck error

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -19,6 +19,7 @@ fail_build=0
 has_errors=0
 create_annotation=0
 
+# shellcheck disable=2317  #  this is a signal function
 function cleanup {
   rm -rf "${artifacts_dir}"
   rm -rf "${annotation_dir}"


### PR DESCRIPTION
Shellcheck released a new stable version that has [mistakenly identifies trap functions as unreacheable code](https://www.shellcheck.net/wiki/SC2317#exceptions) so we need to ignore it