### PR TITLE
Allow running the annotate script outside of Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ The docker image to use for running the analysis code. Must be a valid image ref
 
 Default: `ruby:3.1-alpine@sha256:a39e26d0598837f08c75a42c8b0886d9ed5cc862c4b535662922ee1d05272fca`
 
+### `run-in-docker` (optional, boolean)
+
+Default: `true`
+
+Controls whether the JUnit processing should run inside a Docker container. When set to `false`, the processing will run directly on the host using the system's Ruby installation.
+
 ## Developing
 
 To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).

--- a/hooks/command
+++ b/hooks/command
@@ -42,18 +42,22 @@ fi
 echo "--- :junit: Processing the junits"
 
 set +e
-docker \
-  --log-level "error" \
-  run \
-    --rm \
-    --volume "$artifacts_dir:/junits" \
-    --volume "$PLUGIN_DIR/ruby:/src" \
-    --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" \
-    --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT:-}" \
-    --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST:-}" \
-    --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SKIPPED=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SKIPPED:-}" \
-    "${RUBY_IMAGE}" ruby /src/bin/annotate /junits \
-      > "$annotation_path"
+if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_RUN_IN_DOCKER:-true}" =~ "true" ]]; then
+  docker \
+    --log-level "error" \
+    run \
+      --rm \
+      --volume "$artifacts_dir:/junits" \
+      --volume "$PLUGIN_DIR/ruby:/src" \
+      --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" \
+      --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT:-}" \
+      --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST:-}" \
+      --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SKIPPED=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SKIPPED:-}" \
+      "${RUBY_IMAGE}" ruby /src/bin/annotate /junits \
+        > "$annotation_path"
+else
+  ruby "${PLUGIN_DIR}/ruby/bin/annotate" "${artifacts_dir}" > "$annotation_path"
+fi
 
 exit_code=$?
 set -e

--- a/plugin.yml
+++ b/plugin.yml
@@ -30,6 +30,8 @@ configuration:
       type: integer
     ruby-image:
       type: string
+    run-in-docker:
+      type: boolean
   required:
     - artifacts
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -529,34 +529,6 @@ DOCKER_STUB_DEFAULT_OPTIONS='--log-level error run --rm --volume \* --volume \* 
   rm "${annotation_input}"
 }
 
-@test "runs in docker by default" {
-  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
-  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR=false
-
-  stub mktemp \
-    "-d \* : mkdir -p '$artifacts_tmp'; echo '$artifacts_tmp'" \
-    "-d \* : mkdir -p '$annotation_tmp'; echo '$annotation_tmp'"
-
-  stub buildkite-agent \
-    "artifact download \* \* : echo Downloaded artifact \$3 to \$4" \
-    "annotate --context \* --style \* : cat >'${annotation_input}'; echo Annotation added with context \$3 and style \$5, content saved"
-
-  stub docker \
-    "${DOCKER_STUB_DEFAULT_OPTIONS} ruby /src/bin/annotate /junits : echo '<details>Failure</details>' && exit 64"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-
-  assert_output --partial "Annotation added with context junit and style error"
-  assert_equal "$(cat "${annotation_input}")" '<details>Failure</details>'
-
-  unstub mktemp
-  unstub buildkite-agent
-  unstub docker
-  rm "${annotation_input}"
-}
-
 @test "does not run in docker when run-in-docker is false" {
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
   export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR=false


### PR DESCRIPTION
**Why**

This might be a weird request, but I'm curious if it's reasonable to provide a non Docker in Docker (dind) option to run this junit-annotate-buildkite-plugin?

We have a usecase where we don't have sysbox in the container's runtime environment and there isn't a secure way to run dind (We used to mount docker socket but we've removed it due to the the nature of the sensitive workload). However, we still want to use the plugin. Perhaps it makes sense to add an additional option, assuming that Ruby is in the runtime, to run the junit xml analysis and annotation in the runtime environment w/o dind.