### PR TITLE
feat: Add possibility to run plugin without downloading artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Default: `true`
 
 Controls whether the JUnit processing should run inside a Docker container. When set to `false`, the processing will run directly on the host using the system's Ruby installation.
 
+### `download-artifacts` (optional, boolean)
+
+Default: `true`
+
+Controls whether the Junit processing should download the artifacts from buildkite or not. When set to `false`, the plugin expects the artifacts to be present without having to download them. Usefull to run the plugin in the same step as the one generating the test results.
+
 ## Developing
 
 To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).

--- a/hooks/command
+++ b/hooks/command
@@ -33,10 +33,15 @@ function check_size {
 
 trap cleanup EXIT
 
-echo "--- :junit: Download the junits"
-if ! buildkite-agent artifact download "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS}" "$artifacts_dir"; then
-  echo "--- :boom: Could not download artifacts"
-  exit "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILED_DOWNLOAD_EXIT_CODE:-2}"
+if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_DOWNLOAD_ARTIFACTS:-true}" == "true" ]]; then
+  echo "--- :junit: Download the junits"
+  if ! buildkite-agent artifact download "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS}" "$artifacts_dir"; then
+    echo "--- :boom: Could not download artifacts"
+    exit "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILED_DOWNLOAD_EXIT_CODE:-2}"
+  fi
+else
+  echo "--- :junit: Using the provided artifacts"
+    cp -r "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS}" "$artifacts_dir"
 fi
 
 echo "--- :junit: Processing the junits"

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,6 +32,8 @@ configuration:
       type: string
     run-in-docker:
       type: boolean
+    download-artifacts:
+      type: boolean
   required:
     - artifacts
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -557,3 +557,13 @@ DOCKER_STUB_DEFAULT_OPTIONS='--log-level error run --rm --volume \* --volume \* 
   unstub ruby
   rm "${annotation_input}"
 }
+
+@test "does not download artifacts when download-artifacts is false" {
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_ARTIFACTS="junits/*.xml"
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAIL_BUILD_ON_ERROR=false
+  export BUILDKITE_PLUGIN_JUNIT_ANNOTATE_DOWNLOAD_ARTIFACTS=false
+
+  run "$PWD/hooks/command"
+
+  assert_output --partial "Using the provided artifacts"
+}


### PR DESCRIPTION
This feature allows users to use the plugin without having to put the results as artifacts and uyse the plugin in the same step as the tests themselves.