### PR TITLE
Fix permission denied error in container on SELinux systems

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -47,8 +47,8 @@ if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_RUN_IN_DOCKER:-true}" =~ "true" ]]; the
     --log-level "error" \
     run \
       --rm \
-      --volume "$artifacts_dir:/junits" \
-      --volume "$PLUGIN_DIR/ruby:/src" \
+      --volume "$artifacts_dir:/junits:Z" \
+      --volume "$PLUGIN_DIR/ruby:/src:Z" \
       --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_JOB_UUID_FILE_PATTERN:-}" \
       --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_FAILURE_FORMAT:-}" \
       --env "BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST=${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_REPORT_SLOWEST:-}" \


### PR DESCRIPTION
Add `:Z` SELinux label to volume mounts to ensure proper security context
for mounted files, allowing the container to execute the Ruby script.
This fixes an issue with SELinux-enabled environments (e.g. Fedora, Red Hat, Oracle Linux) without impacting other systems (tested against Debian 12).

> Labeling systems like SELinux require that proper labels are placed on volume content mounted into a <<container|pod>>. Without a label, the security system might prevent the processes running inside the <<container|pod>> from using the content. By default, Podman does not change the labels set by the OS.[1]

1. https://docs.podman.io/en/v4.4/markdown/options/volume.html#Footnote1

Fixes #257 