### PR TITLE
Add compatibility table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Default: `true`
 
 Controls whether the JUnit processing should run inside a Docker container. When set to `false`, the processing will run directly on the host using the system's Ruby installation.
 
+## Compatibility
+
+| Plugin | Elastic Stack | Agent Stack K8s | Hosted (Mac) | Hosted (Linux) | Notes |
+| ------ | :-----------: | :-------------: | :----: | :----: |:---- |
+| Junit Annotate | ✅ | ⚠️ | ⚠️ | ✅ | **K8s** - Out of the box, requires `run-in-docker: false` and a container image with `ruby` installed<br>Likely requires some complex podSpec (pending investigation)<br>**Hosted (Mac)** - instances do not ship with the Docker daemon, but can use a `ruby` binary on the agent |
+
+- ✅ Fully supported (all combinations of attributes have been tested to pass)
+- ⚠️ Partially supported (some combinations cause errors/issues)
+- ❌ Not supported
+
+
 ## Developing
 
 To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).


### PR DESCRIPTION
## Changes

- Adds the compatibility table to the README so that it can be ingested in to the docs and easily grok'd
