### PR TITLE
`hooks/command`: Use `/usr/bin/env` for shell directive instead of hard-coded paths

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
This PR:
* Replaces the Bash shebang with one that uses `/usr/bin/env` to find the `bash` executable on the machine so that non-FHS systems (like NixOS) are supported